### PR TITLE
dl-zero-de is a compatible license

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,6 +8,11 @@ not required, but is encouraged, to appear in the .geojson source file.
 imagery sources are also compatible with tracing and do not require any additional
 permission.  Attribution of an OGL source is required to appear in the .geojson source file.
 
+- :white_check_mark: [Data licence Germany - Zero - Version 2.0 (dl-zero-de/2.0)](https://www.govdata.de/dl-de/zero-2-0)
+imagery sources are directly compatible with tracing on OpenHistoricalMap and do not
+require any additional permission. Attribution of such a source is
+not required, but is encouraged, to appear in the .geojson source file.
+
 - :question: [Creative Commons with condition (CC BY, CC BY-NC, CC BY-SA)](https://creativecommons.org/share-your-work/licensing-types-examples/) imagery sources are directly compatible with tracing on
 OpenHistoricalMap. Attribution of Creative Commons sources is required.
 


### PR DESCRIPTION
"Datenlizenz Deutschland – Zero – Version 2.0" (Data licence Germany - Zero - Version 2.0) is a compatible license as it does not require any attribution and permits any use without restrictions or conditions.

See https://www.govdata.de/dl-de/zero-2-0 for further details.